### PR TITLE
Debugging sorting segfault

### DIFF
--- a/bindings/python/ensmallen_graph/__init__.py
+++ b/bindings/python/ensmallen_graph/__init__.py
@@ -1,10 +1,11 @@
 from .ensmallen_graph import EnsmallenGraph # pylint: disable=import-error
 from .ensmallen_graph import preprocessing # pylint: disable=import-error
-from .automatic_graphs import StringPPI, KGCOVID19
+from .automatic_graphs import StringPPI, KGCOVID19, CompleteStringPPI
 
 __all__ = [
     "StringPPI",
     "KGCOVID19",
+    "CompleteStringPPI",
     "EnsmallenGraph",
     "preprocessing"
 ]

--- a/bindings/python/ensmallen_graph/automatic_graph_retrieval.py
+++ b/bindings/python/ensmallen_graph/automatic_graph_retrieval.py
@@ -50,7 +50,7 @@ class AutomaticallyRetrievedGraph:
         self._downloader = BaseDownloader(
             auto_extract=True,
             target_directory=self._cache_path,
-            verbose=self._verbose
+            verbose=boolself._verbose
         )
 
     def __call__(self) -> EnsmallenGraph:
@@ -63,6 +63,6 @@ class AutomaticallyRetrievedGraph:
                 for key, value in self._graph["arguments"].items()
             },
             directed=self._directed,
-            verbose=self._verbose,
+            verbose=bool(self._verbose),
             name=self._name
         )

--- a/bindings/python/ensmallen_graph/automatic_graph_retrieval.py
+++ b/bindings/python/ensmallen_graph/automatic_graph_retrieval.py
@@ -50,7 +50,7 @@ class AutomaticallyRetrievedGraph:
         self._downloader = BaseDownloader(
             auto_extract=True,
             target_directory=self._cache_path,
-            verbose=boolself._verbose
+            verbose=self._verbose
         )
 
     def __call__(self) -> EnsmallenGraph:

--- a/bindings/python/ensmallen_graph/automatic_graph_retrieval.py
+++ b/bindings/python/ensmallen_graph/automatic_graph_retrieval.py
@@ -11,7 +11,7 @@ class AutomaticallyRetrievedGraph:
         self,
         name: str,
         directed: bool = False,
-        verbose: bool = True,
+        verbose: int = 2,
         cache_path: str = "graphs"
     ):
         """Create new automatically retrieved graph.
@@ -23,7 +23,7 @@ class AutomaticallyRetrievedGraph:
         directed: bool = False,
             Wether to load the graph as directed or undirected.
             By default false.
-        verbose: bool = True,
+        verbose: int = 2,
             Wether to show loading bars.
         cache_path: str = "graphs",
             Where to store the downloaded graphs.

--- a/bindings/python/ensmallen_graph/automatic_graphs.py
+++ b/bindings/python/ensmallen_graph/automatic_graphs.py
@@ -5,7 +5,7 @@ from .automatic_graph_retrieval import AutomaticallyRetrievedGraph
 
 def StringPPI(
     directed: bool = False,
-    verbose: bool = True,
+    verbose: int = 2,
     cache_path: str = "graphs"
 ) -> EnsmallenGraph:
     """Return new instance of the StringPPI graph.
@@ -18,7 +18,7 @@ def StringPPI(
     directed: bool = False,
         Wether to load the graph as directed or undirected.
         By default false.
-    verbose: bool = True,
+    verbose: int = 2,
         Wether to show loading bars.
     cache_path: str = "graphs",
         Where to store the downloaded graphs.
@@ -34,10 +34,43 @@ def StringPPI(
         cache_path=cache_path
     )()
 
+def CompleteStringPPI(
+    directed: bool = False,
+    verbose: int = 2,
+    cache_path: str = "graphs"
+) -> EnsmallenGraph:
+    """Return new instance of the Complete StringPPI graph.
+
+    THIS GRAPH IS VERY VERY BIG, ABOUT 43GB!
+
+    The retrieved graph is automatically retrieved directly from the STRING
+    website, that is https://string-db.org/.
+
+    Parameters
+    -------------------
+    directed: bool = False,
+        Wether to load the graph as directed or undirected.
+        By default false.
+    verbose: int = 2,
+        Wether to show loading bars.
+    cache_path: str = "graphs",
+        Where to store the downloaded graphs.
+
+    Returns
+    -----------------------
+    String PPI graph.
+    """
+    return AutomaticallyRetrievedGraph(
+        "CompleteStringPPI",
+        directed=directed,
+        verbose=verbose,
+        cache_path=cache_path
+    )()
+
 
 def KGCOVID19(
     directed: bool = False,
-    verbose: bool = True,
+    verbose: int = 2,
     cache_path: str = "graphs"
 ) -> EnsmallenGraph:
     """Return new instance of the KG-COVID19 graph.
@@ -50,7 +83,7 @@ def KGCOVID19(
     directed: bool = False,
         Wether to load the graph as directed or undirected.
         By default false.
-    verbose: bool = True,
+    verbose: int = 2,
         Wether to show loading bars.
     cache_path: str = "graphs",
         Where to store the downloaded graphs.

--- a/bindings/python/ensmallen_graph/graphs.json
+++ b/bindings/python/ensmallen_graph/graphs.json
@@ -19,7 +19,7 @@
             "edge_path": "protein.links.v11.0.txt",
             "sources_column": "protein1",
             "destinations_column": "protein2",
-            "sep": " ",
+            "edge_separator": " ",
             "weights_column": "combined_score"
         }
     },

--- a/bindings/python/ensmallen_graph/graphs.json
+++ b/bindings/python/ensmallen_graph/graphs.json
@@ -19,6 +19,7 @@
             "edge_path": "protein.links.v11.0.txt",
             "sources_column": "protein1",
             "destinations_column": "protein2",
+            "sep": " ",
             "weights_column": "combined_score"
         }
     },

--- a/bindings/python/ensmallen_graph/graphs.json
+++ b/bindings/python/ensmallen_graph/graphs.json
@@ -11,6 +11,18 @@
             "weights_column": "score"
         }
     },
+    "CompleteStringPPI": {
+        "urls": [
+            "https://stringdb-static.org/download/protein.links.v11.0.txt.gz"
+        ],
+        "arguments": {
+            "edge_path": "protein.links.v11.0.txt",
+            "sources_column": "item_id_a",
+            "destinations_column": "item_id_b",
+            "edge_types_column": "mode",
+            "weights_column": "score"
+        }
+    },
     "KG-COVID19": {
         "urls": [
             "https://kg-hub.berkeleybop.io/kg-covid-19/current/kg-covid-19.tar.gz"

--- a/bindings/python/ensmallen_graph/graphs.json
+++ b/bindings/python/ensmallen_graph/graphs.json
@@ -17,10 +17,9 @@
         ],
         "arguments": {
             "edge_path": "protein.links.v11.0.txt",
-            "sources_column": "item_id_a",
-            "destinations_column": "item_id_b",
-            "edge_types_column": "mode",
-            "weights_column": "score"
+            "sources_column": "protein1",
+            "destinations_column": "protein2",
+            "weights_column": "combined_score"
         }
     },
     "KG-COVID19": {

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -37,7 +37,7 @@ indicatif = {version="0.15.0", features = ["rayon"]}
 arbitrary = { version = "0.4.5", features = ["derive"] }
 roaring = { git = "https://github.com/zommiommy/roaring-rs", branch = "master" }
 vec_rand = { git = "https://github.com/zommiommy/vec_rand", branch = "master" }
-elias_fano_rust = { git = "https://github.com/zommiommy/elias_fano_rust", branch = "master", features = ["unsafe"] }
+elias_fano_rust = { git = "https://github.com/zommiommy/elias_fano_rust", branch = "master"}
 
 [build]
 rustflags = ["-C target-cpu=native", "-C target-feature=-crt-static"]
@@ -47,9 +47,9 @@ target="x86_64-unknown-linux-musl"
 opt-level = 3
 codgen-units=1
 lto = "fat"
-overflow-checks = false     # Disable integer overflow checks.
-debug = false             # Include debug info.
-debug-assertions = false  # Enables debug assertions.
+overflow-checks = true     # Disable integer overflow checks.
+debug = true             # Include debug info.
+debug-assertions = true  # Enables debug assertions.
 
 [profile.test]
 overflow-checks = true     # Disable integer overflow checks.

--- a/graph/src/constructors.rs
+++ b/graph/src/constructors.rs
@@ -292,7 +292,7 @@ pub(crate) fn parse_unsorted_quadruples(
     let pb = get_loading_bar(verbose, "Building sorted graph", edges.len());
 
     info!("Sorting edges.");
-    edges.par_sort_unstable_by(|(src1, dst1, edt1, _), (src2, dst2, edt2, _)|{
+    edges.par_sort_by(|(src1, dst1, edt1, _), (src2, dst2, edt2, _)|{
         (*src2, *dst2, *edt2).cmp(&(*src1, *dst1, *edt1))
     });
 

--- a/graph/src/constructors.rs
+++ b/graph/src/constructors.rs
@@ -362,7 +362,9 @@ pub(crate) fn parse_string_unsorted_edges<'a>(
         
             parse_unsorted_quadruples(edge_quadruples, ignore_duplicated_edges, verbose)
     };
+    info!("Building nodes reverse mapping.");
     nodes.build_reverse_mapping()?;
+    info!("Building edge types reverse mapping.");
     edge_types_vocabulary.build_reverse_mapping()?;
 
     Ok((edges_number, edges_iter, nodes, edge_types_vocabulary))
@@ -376,6 +378,7 @@ pub(crate) fn build_edges(
     directed: bool,
     directed_edge_list: bool
 ) -> Result<(EliasFano, EliasFano, EdgeT, EdgeT, NodeT, NodeT, NodeT, u8, u64), String> {
+    info!("Started building of compressed EliasFano edges data structure.");
     let node_bits = get_node_bits(nodes_number);
     let node_bit_mask = (1 << node_bits) - 1;
     let mut edges: EliasFano = EliasFano::new(

--- a/graph/src/constructors.rs
+++ b/graph/src/constructors.rs
@@ -292,12 +292,12 @@ pub(crate) fn parse_unsorted_quadruples(
     let pb = get_loading_bar(verbose, "Building sorted graph", edges.len());
 
     info!("Sorting edges.");
-    edges.par_sort_unstable_by(|(src1, dst1, _, _), (src2, dst2, _, _)|{
-        (*src1, *dst1).cmp(&(*src2, *dst2))
+    edges.par_sort_unstable_by(|(src1, dst1, edt1, _), (src2, dst2, edt2, _)|{
+        (*src2, *dst2, *edt2).cmp(&(*src1, *dst1, *edt1))
     });
 
     if ignore_duplicated_edges{
-        info!("Removing duplicated edges if detected.");
+        info!("Removing duplicated edges.");
         edges.dedup_by(|(src1, dst1, edt1, _), (src2, dst2, edt2, _)|{
             (src1, dst1, edt1) == (src2, dst2, edt2)
         });


### PR DESCRIPTION
Patched successfully the SEGFAULT stemming from the unstable quicksort.

This may need to be further explored within Rust implementation of quicksort since it seems to be [a known error with sorting algorithms](https://stackoverflow.com/questions/6978201/why-does-stdsort-throw-a-segmentation-fault-on-this-code).